### PR TITLE
Add deletion of a key with CAS value (DelCas)

### DIFF
--- a/client/mc.go
+++ b/client/mc.go
@@ -189,6 +189,16 @@ func (c *Client) Del(vb uint16, key string) (*gomemcached.MCResponse, error) {
 		Key:     []byte(key)})
 }
 
+// DelCas attempts to delete a key with a CAS.
+func (c *Client) DelCas(vb uint16, key string, cas uint64) (*gomemcached.MCResponse, error) {
+	return c.Send(&gomemcached.MCRequest{
+		Opcode:  gomemcached.DELETE,
+		VBucket: vb,
+		Key:     []byte(key),
+		Cas:     cas,
+	})
+}
+
 // Get a random document
 func (c *Client) GetRandomDoc() (*gomemcached.MCResponse, error) {
 	return c.Send(&gomemcached.MCRequest{


### PR DESCRIPTION
In order, to be able to use Delete with CAS in go-couchbase client, we had to add CAS based deletion to the gomemcached client.  PR to the go-couchbase is incoming, once this gets merged.

The behaviour for the deletion in memcached binary protocol seems to be undefined, but in couchbase it's a valid parameter implemented in some of it's clients. As this is a forked version of gomemcached, living under couchbase, I assumed it's safe.

https://groups.google.com/forum/#!searchin/memcached/cas$20delete%7Csort:relevance/memcached/eWs-mbyQuew/2nmYCd2-V3kJ