### PR TITLE
Fix potential data race in mcdebug whilst collecting memcached client op statistics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.swp
 /gocache/gocache
 c.out
+.idea

--- a/debug/mcdebug_test.go
+++ b/debug/mcdebug_test.go
@@ -1,0 +1,30 @@
+package mcdebug
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMcopsDataRace(t *testing.T) {
+	mcSent := &mcops{}
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		mcSent.count(1, 2, fmt.Errorf("mcdebug: throw some error")) // write
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		fmt.Println(mcSent.String()) // concurrent read
+	}()
+
+	wg.Wait()
+	require.NotEqual(t, `{"bytes":{},"errs":{},"ops":{}}`, mcSent.String())
+	fmt.Println(mcSent.String())
+}


### PR DESCRIPTION
This PR contains the fix for potential data race in `mcdebug` whilst collecting `memcached` client op statistics. All access of `mcops` fields (`moved`, `success`, `errored`) needs to be synchronized including read.

**Potential Data Race**
```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/sarathkumarsivan/sync_gateway/godeps:/Users/sarathkumarsivan/go #gosetup
/usr/local/go/bin/go test -json -race ./... #gosetup
=== RUN   TestMcopsDataRace
==================
WARNING: DATA RACE
Read at 0x00c00011ec88 by goroutine 10:
  _/Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug.(*mcops).String()
      /Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug/mcdebug.go:36 +0xb6
  _/Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug.TestMcopsDataRace.func2()
      /Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug/mcdebug_test.go:24 +0x87

Previous write at 0x00c00011ec88 by goroutine 9:
  sync/atomic.AddInt64()
      /usr/local/go/src/runtime/race_amd64.s:276 +0xb
  _/Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug.(*mcops).count()
      /Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug/mcdebug.go:58 +0xb0
  _/Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug.TestMcopsDataRace.func1()
      /Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug/mcdebug_test.go:18 +0xc2

Goroutine 10 (running) created at:
  _/Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug.TestMcopsDataRace()
      /Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug/mcdebug_test.go:22 +0x135
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 9 (finished) created at:
  _/Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug.TestMcopsDataRace()
      /Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug/mcdebug_test.go:16 +0xf2
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
==================
==================
WARNING: DATA RACE
Read at 0x00c00011fc98 by goroutine 10:
  _/Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug.(*mcops).String()
      /Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug/mcdebug.go:38 +0x1cd
  _/Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug.TestMcopsDataRace.func2()
      /Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug/mcdebug_test.go:24 +0x87

Previous write at 0x00c00011fc98 by goroutine 9:
  sync/atomic.AddInt64()
      /usr/local/go/src/runtime/race_amd64.s:276 +0xb
  _/Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug.(*mcops).count()
      /Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug/mcdebug.go:56 +0x85
  _/Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug.TestMcopsDataRace.func1()
      /Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug/mcdebug_test.go:18 +0xc2

Goroutine 10 (running) created at:
  _/Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug.TestMcopsDataRace()
      /Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug/mcdebug_test.go:22 +0x135
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 9 (finished) created at:
  _/Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug.TestMcopsDataRace()
      /Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug/mcdebug_test.go:16 +0xf2
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
==================
{"bytes":{"SET":2,"total":2},"errs":{"SET":1,"total":1},"ops":{}}
{"bytes":{"SET":2,"total":2},"errs":{"SET":1,"total":1},"ops":{}}
--- FAIL: TestMcopsDataRace (0.02s)
    testing.go:853: race detected during execution of test
FAIL
FAIL	_/Users/sarathkumarsivan/workspace/sync_gateway/godeps/src/github.com/couchbase/gomemcached/debug	0.299s

Process finished with exit code 1
```